### PR TITLE
fixed incorrect order of scrapeData call

### DIFF
--- a/Option Scraper.ipynb
+++ b/Option Scraper.ipynb
@@ -349,7 +349,7 @@
     "\n",
     "for i in range(num_batches):\n",
     "    if (startIdx + (i*bs)) < (499 - bs): # only scrape data if we won't exceed the ticker list\n",
-    "        scrapeData(startIdx+i*bs, bs, rf, verbose, wait_period)\n",
+    "        scrapeData(startIdx+i*bs, bs, rf, wait_period, verbose)\n",
     "        if verbose:\n",
     "            print(\"Waiting for to avoid server denial\")\n",
     "            print()\n",


### PR DESCRIPTION
Call of scrapeData in the main loop had arguments wait_period and verbose in the wrong order.